### PR TITLE
Using wallet-selector signIn instead of autoSignIn function

### DIFF
--- a/src/lib/core/setup.ts
+++ b/src/lib/core/setup.ts
@@ -36,12 +36,12 @@ export function setupKeypom({
 			desiredUrl
 		})
 
-		let signInSuccess = true;
-		try {
-			await keypomWallet.signIn();
-		} catch (e) {
-			signInSuccess = false;
-		}
+		// let signInSuccess = true;
+		// try {
+		// 	await keypomWallet.signIn();
+		// } catch (e) {
+		// 	signInSuccess = false;
+		// }
 
 		// await waitFor(() => !!window.near?.isSignedIn(), { timeout: 300 }).catch(() => false);
 		return {
@@ -56,11 +56,14 @@ export function setupKeypom({
 				deprecated,
 				available: true,
 			},
-			init: (config) =>
-				initKeypomWallet({
+			init: async (config) => {
+				const wallet = await initKeypomWallet({
 					...config,
 					keypomWallet
-				}),
+				});
+				await wallet.signIn({ contractId: "" });
+				return wallet;
+			},
 		};
 	};
 }

--- a/src/lib/core/setup.ts
+++ b/src/lib/core/setup.ts
@@ -61,7 +61,7 @@ export function setupKeypom({
 					...config,
 					keypomWallet
 				});
-				await wallet.signIn({ contractId: "" });
+				await wallet.signIn();
 				return wallet;
 			},
 		};

--- a/src/lib/core/types.ts
+++ b/src/lib/core/types.ts
@@ -26,7 +26,7 @@ interface SignAndSendTransactionParams {
 export interface KeypomWalletProtocol {
     networkId: string;
 
-    signIn(params: SignInParams): Promise<Array<Account>>;
+    signIn(): Promise<Array<Account>>;
     signOut(): Promise<void>;
     getAccounts(): Promise<Array<Account>>;
     verifyOwner(params: VerifyOwnerParams): Promise<VerifiedOwner | void>;
@@ -50,4 +50,4 @@ export type SelectorInit = WalletBehaviourFactory<
 >;
 
 export type KeypomWalletType = InjectedWallet &
-  Omit<Omit<KeypomWalletProtocol, "getAccounts">, "signIn">;
+  Omit<KeypomWalletProtocol, "getAccounts">;

--- a/src/lib/core/wallet.ts
+++ b/src/lib/core/wallet.ts
@@ -244,7 +244,7 @@ export class KeypomWallet implements KeypomWalletProtocol {
 
         console.log("auto signing in!");
         // Auto sign in (mess with local storage)
-        autoSignIn(this.accountId, this.secretKey);
+        // autoSignIn(this.accountId, this.secretKey);
  
         const accountObj = new Account(this.connection, this.accountId!);
         return [accountObj];

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,35 +808,20 @@ js-yaml@^3.14.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-keypom-js@^1.3.2-rc.1:
-  version "1.3.2-rc.1"
-  resolved "https://registry.yarnpkg.com/keypom-js/-/keypom-js-1.3.2-rc.1.tgz#d6013c01235ca74c32f1f8fa2c0b675fb3372046"
-  integrity sha512-w0xyH+UxbKs0+oRaw1LkgXcknp1XHNeQRrEfYiVtCzhbsBp04CVJsgaOkOSZTlh0oteaeJ3I9PRB93BVs/o5OA==
-  dependencies:
-    "@near-wallet-selector/core" "^7.5.0"
-    "@types/react" "^18.0.26"
-    ava "^4.3.3"
-    bn.js "^5.2.1"
-    dotenv "^16.0.3"
-    near-api-js "^0.44.2"
-    near-seed-phrase "^0.2.0"
-    react "^18.2.0"
-    typescript "^4.8.4"
-
 keypom-js@^1.3.4:
-  version "1.3.4-rc.1"
-  resolved "https://registry.yarnpkg.com/keypom-js/-/keypom-js-1.3.4-rc.1.tgz#703e28c8299e23d5a32cda6063cc3a449ee77ae8"
-  integrity sha512-4pGTTPNAKuK24xvPq7iQSL35xT5NTUtD2JapmJrewdPmIBmvKyN6FdcyKV5fAWcMbCkeeyxlS+JZIWtqEAZdjw==
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/keypom-js/-/keypom-js-1.3.7.tgz#a6a86c30a84e52f8e6475200158b07bf0819150f"
+  integrity sha512-6/krFLyNil3pANCf6XAANDFsl95bzZfGZtVxSCUlBkdO+ccv/XbO5H20PrbXwtxq9OuxNW3Miu8H60Y7WGpF5Q==
   dependencies:
     "@near-wallet-selector/core" "^7.5.0"
     "@types/react" "^18.0.26"
     ava "^4.3.3"
     bn.js "^5.2.1"
     dotenv "^16.0.3"
-    keypom-js "^1.3.2-rc.1"
     near-api-js "^0.44.2"
     near-seed-phrase "^0.2.0"
     react "^18.2.0"
+    react-dom "18.2.0"
     typescript "^4.8.4"
 
 load-json-file@^7.0.0:


### PR DESCRIPTION
This is just a quick assumption. 

I haven't tested these changes since I don't know how to generate the keypom url. If I manage to generate it in the meantime then I will update this PR.

Basically these changes will call the internal near-wallet-selector signIn function which will handle the internal state instead of the autoSignIn function. The signIn call needs to happed in that particular peace of code because we need to initialize the wallet module before calling it. That will run all of the internal state functions and will simulate a real sign in.

This approach does not change anything inside the near-wallet-selector codebase.